### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/josejustino/clean-react/security/code-scanning/2](https://github.com/josejustino/clean-react/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to restrict GitHub Actions' default token permissions according to the principle of least privilege. Following CodeQL's advice, set `permissions: contents: read` at the workflow root (top-level), ensuring that all jobs—unless specifically overridden—will inherit this restriction. Place this block directly after the `name` declaration and before `on:` to apply globally. This avoids unnecessary write or admin permissions, offering the best security posture with retained functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
